### PR TITLE
Parse XML Authn Response

### DIFF
--- a/django3_auth_saml2/views.py
+++ b/django3_auth_saml2/views.py
@@ -102,6 +102,7 @@ def sso_acs(req: WSGIRequest) -> HttpResponseRedirect:
     # an existing Django user record, create one if we should, or reject the
     # user if we should not.
 
+    authn_response.parse_assertion()
     user_name = authn_response.name_id.text
     backend_name = SAML2_AUTH_CONFIG['AUTHENTICATION_BACKEND']
     backend_obj = load_backend(backend_name)


### PR DESCRIPTION
This PR will resolve the following error when trying to authenticate with SSO.

```
Internal Server Error: /api/plugins/sso/acs/
Traceback (most recent call last):
  File "/opt/netbox/venv/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/opt/netbox/venv/lib/python3.8/site-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/opt/netbox/venv/lib/python3.8/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/opt/netbox/venv/lib/python3.8/site-packages/django3_auth_saml2/views.py", line 105, in sso_acs
    user_name = authn_response.name_id.text
AttributeError: 'NoneType' object has no attribute 'text'
```