### PR TITLE
Update pysaml2 automatically

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 django>=3
-pysaml2==6.5.0
+pysaml2>=6.5.0


### PR DESCRIPTION
I could not detect a reason to use old versions of pysaml2, but signing of AuthnRequests changed a bit during the versions