### PR TITLE
Fix Signing of SAML2 Requests

### DIFF
--- a/django3_auth_saml2/views.py
+++ b/django3_auth_saml2/views.py
@@ -149,10 +149,11 @@ def signin(req: WSGIRequest) -> HttpResponseRedirect:
     # URL parameter to pass the 'next-url' value back to the sso handler.
 
     saml_client = _get_saml_client(req)
-    req_id, info = saml_client.prepare_for_authenticate()
+    sign = bool(saml_client.config.getattr("authn_requests_signed", "sp"))
+    req_id, info = saml_client.prepare_for_authenticate(
+        sign=sign, relay_state=next_url)
 
     redirect_url = dict(info['headers'])['Location']
-    redirect_url += f"&RelayState={next_url}"
 
     # This causes the web client to go to the SSO SAML system to force the use
     # to use that system to authenticate.


### PR DESCRIPTION
pysaml2 requires to set `sign=True` during `prepare_for_authenticate`. We also move `relay_state` to `prepare_for_authenticate` to make sure the generated signatures are valid